### PR TITLE
Bug 178 - backUrl in Delete Report dialogue

### DIFF
--- a/src/main/webapp/js/app/views/DeleteObjectView.js
+++ b/src/main/webapp/js/app/views/DeleteObjectView.js
@@ -52,7 +52,8 @@ define([
                 }
             };
             this.targetObject.destroy(callbacks);
-            $.mobile.changePage(this.backPage, {role: 'page', reverse: false, changeHash:false});
+            const backUrl = this.backPage.context.baseURI + "#test-reports";
+            window.location.replace(backUrl);
             // Will change to the correct url and trigger a rerender event
             // window.location.href = "#test-objects-page";
         },
@@ -60,7 +61,8 @@ define([
         cancel: function(e){
             e.preventDefault();
             console.log("Canceled "+this.typeName+" deletion");
-            $.mobile.changePage(this.backPage, {role: 'page', reverse: false, changeHash:false});
+            const backUrl = this.backPage.context.baseURI + "#test-reports";
+            window.location.replace(backUrl);
 
         },
     });


### PR DESCRIPTION
Fixing for https://github.com/etf-validator/etf-webapp/issues/178
This sets the "backUrl" reference on the cancel button and the confirm button to "baseUrl + #test-reports"