### PR TITLE
Security patch for hiding stacktrace

### DIFF
--- a/src/main/java/de/interactive_instruments/etf/webapp/controller/EtfConfigController.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/controller/EtfConfigController.java
@@ -108,6 +108,8 @@ public class EtfConfigController implements PropertyHolder {
 
     public static final String ETF_SHOW_USERNAME = "etf.show.username";
 
+    public static final String ETF_SHOW_SENSITIVEINFORMATION = "etf.show.sensitiveinformation";
+
     @Autowired
     private ServletContext servletContext;
 
@@ -156,8 +158,8 @@ public class EtfConfigController implements PropertyHolder {
                     put(ETF_TESTDATA_UPLOAD_DIR, "http_uploads");
                     put(ETF_PARALLEL_EXECUTIONS, "" + Runtime.getRuntime().availableProcessors());
                     put(ETF_QUEUE_SIZE, "" + Runtime.getRuntime().availableProcessors() * 3);
-
-                    put(ETF_SHOWUSERNAME, "true");
+                    put(ETF_SHOW_USERNAME, "false");
+                    put(ETF_SHOW_SENSITIVEINFORMATION, "false");
 
                 }
             });
@@ -719,7 +721,8 @@ public class EtfConfigController implements PropertyHolder {
         for (Map.Entry<String, String> e : newConfiguration) {
             if (filePathPropertyKeys.contains(e.getKey())) {
                 logger.error("Denied attempt to overwrite path property '{}' in configuration", e.getKey());
-                throw new LocalizableApiError("l.overwriting.path.properties.not.allowed", false,
+                throw new LocalizableApiError("l.overwriting.path.properties.not.allowed",
+                        !(Boolean.parseBoolean(this.configProperties.getProperty(ETF_SHOW_SENSITIVEINFORMATION))),
                         HttpStatus.FORBIDDEN.value());
             }
         }

--- a/src/main/java/de/interactive_instruments/etf/webapp/controller/FileStorage.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/controller/FileStorage.java
@@ -130,14 +130,19 @@ class FileStorage {
                                 tmpSubDir.deleteDirectory();
                                 destinationSubDir.deleteDirectory();
                             } catch (IOException ignore) {}
-                            throw new LocalizableApiError("l.download.failed", false, 400, e);
+                            throw new LocalizableApiError("l.download.failed", !(Boolean.parseBoolean(
+                                    EtfConfigController.getInstance().getProperty(
+                                            EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                                    400, e);
                         }
                         prepare(download, destinationSubDir, download.getName(), fileFilter, remainingDownloadSize);
                     }
                 }
                 checkSize(destinationSubDir);
             } catch (IOsizeLimitExceededException e) {
-                throw new LocalizableApiError("l.max.download.size.exceeded", false, 400, e, maxStorageSizeHr);
+                throw new LocalizableApiError("l.max.download.size.exceeded", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, e, maxStorageSizeHr);
             }
             return destinationSubDir;
         }
@@ -181,7 +186,9 @@ class FileStorage {
                     tmpSubDir.deleteDirectory();
                     destinationSubDir.deleteDirectory();
                 } catch (IOException ignore) {}
-                throw new LocalizableApiError("l.max.upload.size.exceeded", false, 400, e, maxStorageSizeHr);
+                throw new LocalizableApiError("l.max.upload.size.exceeded", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, e, maxStorageSizeHr);
             } catch (IOException e) {
                 try {
                     tmpSubDir.deleteDirectory();
@@ -243,7 +250,9 @@ class FileStorage {
             try {
                 tmpFile.unzipTo(storageSubDir, fileFilter, maxSize);
             } catch (IOsizeLimitExceededException e) {
-                throw new LocalizableApiError("l.max.extract.size.exceeded", false, 400, e, maxStorageSizeHr);
+                throw new LocalizableApiError("l.max.extract.size.exceeded", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, e, maxStorageSizeHr);
             } catch (IOException e) {
                 throw new LocalizableApiError("l.decompress.failed", e);
             } finally {
@@ -253,7 +262,9 @@ class FileStorage {
         } else {
             if (!baseFilter.content().accept(type)) {
                 tmpFile.delete();
-                throw new LocalizableApiError("l.upload.invalid", false, 400, type);
+                throw new LocalizableApiError("l.upload.invalid", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, type);
             }
             try {
                 tmpFile.moveTo(storageSubDir.getPath() + File.separator + IFile.sanitize(originalFilename));

--- a/src/main/java/de/interactive_instruments/etf/webapp/controller/LocalizableApiError.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/controller/LocalizableApiError.java
@@ -105,9 +105,21 @@ public class LocalizableApiError extends LocalizableError {
         sc = 400;
     }
 
+    public LocalizableApiError(final boolean sensitive, final HttpMessageNotReadableException e) {
+        super(e.getMessage().contains("Required request body is missing:") ? "l.json.request.body.missing" : "", e);
+        sensitiveInformation = sensitive;
+        sc = 400;
+    }
+
     public LocalizableApiError(final FileUploadBase.SizeLimitExceededException exception) {
         super("l.max.upload.size.exceeded");
         sensitiveInformation = false;
+        sc = 413;
+    }
+
+    public LocalizableApiError(final boolean sensitive, final FileUploadBase.SizeLimitExceededException exception) {
+        super("l.max.upload.size.exceeded");
+        sensitiveInformation = sensitive;
         sc = 413;
     }
 
@@ -181,12 +193,35 @@ public class LocalizableApiError extends LocalizableError {
         sc = 404;
     }
 
+    public LocalizableApiError(final boolean sensitive, final JsonMappingException e) {
+        super("l.json.mapping.error", e,
+                e.getLocation().getLineNr(),
+                e.getLocation().getColumnNr(),
+                e.getPath().get(0).getFieldName(),
+                e.getPath().get(0).getFrom().getClass().getSimpleName(),
+                e.getMessage().indexOf("\n at [") != 0 ? e.getMessage().substring(0, e.getMessage().indexOf("\n at ["))
+                        : "unknown"
+
+        );
+        sensitiveInformation = sensitive;
+        sc = 404;
+    }
+
     public LocalizableApiError(final JsonParseException e) {
         super("l.json.parse.error", e,
                 e.getLocation().getLineNr(),
                 e.getLocation().getColumnNr(),
                 e.getOriginalMessage());
         sensitiveInformation = false;
+        sc = 404;
+    }
+
+    public LocalizableApiError(final boolean sensitive, final JsonParseException e) {
+        super("l.json.parse.error", e,
+                e.getLocation().getLineNr(),
+                e.getLocation().getColumnNr(),
+                e.getOriginalMessage());
+        sensitiveInformation = sensitive;
         sc = 404;
     }
 

--- a/src/main/java/de/interactive_instruments/etf/webapp/controller/RestExceptionHandler.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/controller/RestExceptionHandler.java
@@ -92,19 +92,27 @@ class RestExceptionHandler {
             status = ((LocalizableApiError) exception.getCause()).getStatus();
             conv = null;
         } else if (exception.getCause() instanceof JsonMappingException) {
-            final LocalizableApiError e = new LocalizableApiError((JsonMappingException) exception.getCause());
+            final LocalizableApiError e = new LocalizableApiError(!(Boolean.parseBoolean(
+                    EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                    (JsonMappingException) exception.getCause());
             conv = new ApiError(e, request.getRequestURL().toString(), applicationContext);
             status = e.sc;
         } else if (exception.getCause() instanceof JsonParseException) {
-            final LocalizableApiError e = new LocalizableApiError((JsonParseException) exception.getCause());
+            final LocalizableApiError e = new LocalizableApiError(!(Boolean.parseBoolean(
+                    EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                    (JsonParseException) exception.getCause());
             conv = new ApiError(e, request.getRequestURL().toString(), applicationContext);
             status = e.sc;
         } else if (exception instanceof HttpMessageNotReadableException) {
-            final LocalizableApiError e = new LocalizableApiError((HttpMessageNotReadableException) exception);
+            final LocalizableApiError e = new LocalizableApiError(!(Boolean.parseBoolean(
+                    EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                    (HttpMessageNotReadableException) exception);
             conv = new ApiError(e, request.getRequestURL().toString(), applicationContext);
             status = e.sc;
         } else if (exception instanceof FileUploadBase.SizeLimitExceededException) {
-            final LocalizableApiError e = new LocalizableApiError((FileUploadBase.SizeLimitExceededException) exception);
+            final LocalizableApiError e = new LocalizableApiError(!(Boolean.parseBoolean(
+                    EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                    (FileUploadBase.SizeLimitExceededException) exception);
             conv = new ApiError(e, request.getRequestURL().toString(), applicationContext);
             status = e.sc;
         } else {

--- a/src/main/java/de/interactive_instruments/etf/webapp/controller/StatusController.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/controller/StatusController.java
@@ -293,7 +293,10 @@ public class StatusController {
 
     public void ensureStatusNotMajor() throws LocalizableApiError {
         if (ServiceStatus.valueOf(serviceStatus.get().status) == ServiceStatus.MAJOR) {
-            throw new LocalizableApiError("l.system.status.major", false, 503);
+            throw new LocalizableApiError("l.system.status.major",
+                    !(Boolean.parseBoolean(
+                            EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                    503);
         }
     }
 

--- a/src/main/java/de/interactive_instruments/etf/webapp/controller/TestObjectController.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/controller/TestObjectController.java
@@ -291,7 +291,10 @@ public class TestObjectController implements PreparedDtoResolver<TestObjectDto> 
 
             if (etfConfig.getProperty("etf.testobject.allow.privatenet.access").equals("false")) {
                 if (UriUtils.isPrivateNet(serviceEndpoint)) {
-                    throw new LocalizableApiError("l.rejected.private.subnet.access", false, 403);
+                    throw new LocalizableApiError("l.rejected.private.subnet.access", !(Boolean.parseBoolean(
+                            EtfConfigController.getInstance().getProperty(
+                                    EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                            403);
                 }
             }
 
@@ -300,13 +303,17 @@ public class TestObjectController implements PreparedDtoResolver<TestObjectDto> 
             if (e.getResponseCode() == 400 && e.getUrl() != null) {
                 hash = "0000000000000400";
             } else if ((e.getResponseCode() == 403 || e.getResponseCode() == 401) && e.getUrl() != null) {
-                throw new LocalizableApiError("l.url.secured", false, 400, e, e.getUrl().getHost());
+                throw new LocalizableApiError("l.url.secured", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, e, e.getUrl().getHost());
             } else if (e.getResponseCode() >= 401 && e.getResponseCode() < 500) {
                 throw new LocalizableApiError("l.url.client.error", e);
             } else if (e.getResponseCode() != -1) {
                 throw new LocalizableApiError("l.url.server.error", e);
             } else if (e.getCause() instanceof UnknownHostException && e.getUrl() != null) {
-                throw new LocalizableApiError("l.unknown.host", false, 400, e, e.getUrl().getHost());
+                throw new LocalizableApiError("l.unknown.host", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, e, e.getUrl().getHost());
             } else {
                 throw new LocalizableApiError("l.invalid.url", e);
             }
@@ -330,7 +337,9 @@ public class TestObjectController implements PreparedDtoResolver<TestObjectDto> 
                 }
             }
             if (size > etfConfig.getPropertyAsLong(EtfConfigController.ETF_MAX_UPLOAD_SIZE)) {
-                throw new LocalizableApiError("l.max.upload.size.exceeded", false, 400);
+                throw new LocalizableApiError("l.max.upload.size.exceeded", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400);
             }
         }
 
@@ -369,7 +378,8 @@ public class TestObjectController implements PreparedDtoResolver<TestObjectDto> 
             testObjectDir = uploadCmd.upload();
             resourceName = "upload." + testObject.getResourcesSize();
         } else {
-            throw new LocalizableApiError("l.testobject.required", false, 400);
+            throw new LocalizableApiError("l.testobject.required", !(Boolean.parseBoolean(
+                    EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))), 400);
         }
 
         // Add new resource
@@ -380,17 +390,24 @@ public class TestObjectController implements PreparedDtoResolver<TestObjectDto> 
                 EnumSet.of(FileVisitOption.FOLLOW_LINKS), 5, v);
         if (v.getFileCount() == 0) {
             if (regex != null && !regex.isEmpty()) {
-                throw new LocalizableApiError("l.testObject.regex.null.selection", false, 400, regex);
+                throw new LocalizableApiError("l.testObject.regex.null.selection", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))), 400,
+                        regex);
             } else {
-                throw new LocalizableApiError("l.testObject.testdir.no.xml.gml.found", false, 400);
+                throw new LocalizableApiError("l.testObject.testdir.no.xml.gml.found", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400);
             }
         }
         if (v.getSize() == 0) {
             if (v.getFileCount() == 1) {
-                throw new LocalizableApiError("l.testObject.one.file.with.zero.size", false, 400, v.getFileCount());
+                throw new LocalizableApiError("l.testObject.one.file.with.zero.size", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, v.getFileCount());
             } else {
-                throw new LocalizableApiError("l.testObject.multiple.files.with.zero.size", false, 400,
-                        v.getFileCount());
+                throw new LocalizableApiError("l.testObject.multiple.files.with.zero.size", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400, v.getFileCount());
             }
         }
 
@@ -481,7 +498,8 @@ public class TestObjectController implements PreparedDtoResolver<TestObjectDto> 
             HttpServletRequest request, HttpServletResponse response)
             throws IOException, StorageException, ObjectWithIdNotFoundException, LocalizableApiError {
         if (transientTestObjects.getIfPresent(EidConverter.toEid(id)) != null) {
-            throw new LocalizableApiError("l.temporary.testobject.access", false, 404);
+            throw new LocalizableApiError("l.temporary.testobject.access", !(Boolean.parseBoolean(
+                    EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))), 404);
         }
         streaming.asJson2(testObjectDao, request, response, id);
     }
@@ -519,7 +537,10 @@ public class TestObjectController implements PreparedDtoResolver<TestObjectDto> 
             HttpServletRequest request, HttpServletResponse response)
             throws IOException, StorageException, ObjectWithIdNotFoundException, LocalizableApiError {
         if (transientTestObjects.getIfPresent(EidConverter.toEid(id)) != null) {
-            throw new LocalizableApiError("l.temporary.testobject.access", false, 404);
+            throw new LocalizableApiError("l.temporary.testobject.access",
+                    !(Boolean.parseBoolean(EtfConfigController.getInstance().getProperty(
+                            EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                    404);
         }
         streaming.asXml2(testObjectDao, request, response, id);
     }

--- a/src/main/java/de/interactive_instruments/etf/webapp/controller/TestRunController.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/controller/TestRunController.java
@@ -257,7 +257,8 @@ public class TestRunController implements TestRunEventListener {
             logger.info("TestRun " + testRunDto.getDescriptiveLabel() + " initialized");
             taskPoolRegistry.submitTask(testRun);
         } catch (Exception e) {
-            throw new LocalizableApiError("l.internal.testrun.initialization.error", true, 500, e);
+            throw new LocalizableApiError("l.internal.testrun.initialization.error", !(Boolean.parseBoolean(
+                    EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))), 500, e);
         }
     }
 
@@ -492,7 +493,9 @@ public class TestRunController implements TestRunEventListener {
             }
             // if the list is now empty, the Test Suites are incompatible
             if (requiredTestObjectTypeIds.isEmpty()) {
-                throw new LocalizableApiError("l.ets.supported.testObject.type.incompatible", false, 400);
+                throw new LocalizableApiError("l.ets.supported.testObject.type.incompatible", !(Boolean.parseBoolean(
+                        EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        400);
             }
             testObjectController.initResourcesAndAdd(tO, requiredTestObjectTypeIds);
 
@@ -502,7 +505,9 @@ public class TestRunController implements TestRunEventListener {
                         && tR.getResult().getTestObjects() != null && tR.getResult().getTestObjects().get(0) != null
                         && tO.getId().equals(tR.getResult().getTestObjects().get(0).getId())) {
                     logger.info("Rejecting test start: test object " + tO.getId() + " is in use");
-                    throw new LocalizableApiError("l.testObject.lock", false, 409, tO.getLabel());
+                    throw new LocalizableApiError("l.testObject.lock", !(Boolean.parseBoolean(
+                            EtfConfigController.getInstance().getProperty(EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                            409, tO.getLabel());
                 }
             }
 

--- a/src/main/java/de/interactive_instruments/etf/webapp/dto/ApiError.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/dto/ApiError.java
@@ -28,6 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.i18n.LocaleContextHolder;
 
 import de.interactive_instruments.etf.EtfConstants;
+import de.interactive_instruments.etf.webapp.controller.EtfConfigController;
 import de.interactive_instruments.etf.webapp.controller.LocalizableApiError;
 
 import io.swagger.annotations.ApiModel;
@@ -102,7 +103,13 @@ public class ApiError {
                 this.error = "Internal error";
             }
         }
-        stacktrace = ExceptionUtils.getRootCauseStackTrace(e);
+        if ((localizableApiError != null && localizableApiError.isSensitiveInformation()) ||
+                (localizableApiError == null && !(Boolean.parseBoolean(EtfConfigController.getInstance().getProperty(
+                        EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))))) {
+            stacktrace = new String[]{};
+        } else {
+            stacktrace = ExceptionUtils.getRootCauseStackTrace(e);
+        }
         this.url = url;
     }
 

--- a/src/main/java/de/interactive_instruments/etf/webapp/filter/ApiFilter.java
+++ b/src/main/java/de/interactive_instruments/etf/webapp/filter/ApiFilter.java
@@ -98,7 +98,9 @@ public class ApiFilter extends OncePerRequestFilter {
                 response.setStatus(413);
                 response.setHeader("Content-Type", "application/json");
                 mapper.writeValue(response.getWriter(), new ApiError(new LocalizableApiError(
-                        "l.max.upload.size.exceeded", false, 413), request.getRequestURL().toString(), applicationContext));
+                        "l.max.upload.size.exceeded", !(Boolean.parseBoolean(EtfConfigController.getInstance().getProperty(
+                                EtfConfigController.ETF_SHOW_SENSITIVEINFORMATION))),
+                        413), request.getRequestURL().toString(), applicationContext));
                 response.getWriter().flush();
             }
         }


### PR DESCRIPTION
This patch removes all stacktrace information from error messages making use of the new configuration parameter `ETF_SHOW_SENSITIVEINFORMATION`. We use the value of this parameter in all instances of errors that we found relevant for any API request that goes through the controllers and API classes

- FileStorage
- ApiFilter
- StatusController
- TestObjectController
- TestRunController

We also modified the exception classes

- LocazibleApiError
- ApiError
- RestExceptionHandler

We may need to refactor these changes, but we would like to have your feedback on what lines are redundant.